### PR TITLE
Toggle 'filteractive' class to filter click event

### DIFF
--- a/public/assets/js/public.js
+++ b/public/assets/js/public.js
@@ -69,6 +69,8 @@
 		// Set up the click event for filtering
 		$('#filters').on('click', 'a', function ( event ) {
 			event.preventDefault();
+			$('#filters a.filteractive').removeClass('filteractive');
+			$(this).addClass('filteractive');
 
 			var selector = $(this).attr('data-filter'),
 			    niceSelector = selector.substr(1);


### PR DESCRIPTION
Although a related question, https://github.com/mandiwise/isotope-posts/issues/12, was closed running the latest version I wasn't seeing any active class being added & didn't spot it in the code either so am using an altered version with this added in to do the job.
